### PR TITLE
(GH-22) Add missing semi-colon

### DIFF
--- a/template/ItemTemplate/build.cake
+++ b/template/ItemTemplate/build.cake
@@ -27,7 +27,7 @@ Teardown(ctx =>
 
 Task("Default")
 .Does(() => {
-	Information("Hello Cake!")
+	Information("Hello Cake!");
 });
 
 RunTarget(target);


### PR DESCRIPTION
Adds the missing semi-colon to line 30 of the `build.cake` template to fix #22 