### PR TITLE
(GH-35) Refactor TaskParser to support nested Cake files

### DIFF
--- a/src/Cake.VisualStudio.csproj
+++ b/src/Cake.VisualStudio.csproj
@@ -77,6 +77,7 @@
     <Compile Include="source.extension.cs">
       <DependentUpon>source.extension.vsixmanifest</DependentUpon>
     </Compile>
+    <Compile Include="TaskRunner\ScriptContent.cs" />
     <Compile Include="TaskRunner\TaskParser.cs" />
     <Compile Include="TaskRunner\TaskRunnerOption.cs" />
     <Compile Include="VsCommandTable.cs">

--- a/src/TaskRunner/ScriptContent.cs
+++ b/src/TaskRunner/ScriptContent.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Cake.VisualStudio.TaskRunner
+{
+    internal class ScriptContent
+    {
+        internal ScriptContent(string filePath)
+        {
+            Content = File.ReadAllLines(filePath).ToList();
+            FilePath = new FileInfo(filePath).FullName;
+        }
+
+        private List<string> Content { get; }
+        private Dictionary<int, ScriptContent> Loads { get; set; } = new Dictionary<int, ScriptContent>();
+        private string FilePath { get; set; }
+
+        internal void Parse(string pattern, Func<string, string> stripFunc)
+        {
+            foreach (var line in Content.Where(l => l.StartsWith(pattern)).ToList())
+            {
+                var dirPath = new FileInfo(FilePath).Directory ?? new DirectoryInfo(Directory.GetCurrentDirectory());
+                var path = Path.Combine(dirPath.FullName, stripFunc.Invoke(line));
+                Loads.Add(Content.IndexOf(line), new ScriptContent(path));
+            }
+            foreach (var load in Loads)
+            {
+                load.Value.Parse(pattern, stripFunc);
+            }
+        }
+
+        public override string ToString()
+        {
+            foreach (var load in Loads)
+            {
+                Content[load.Key] = load.Value.ToString();
+            }
+            return string.Join(Environment.NewLine,
+                Content.SelectMany(c => c.Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries)));
+        }
+    }
+}

--- a/src/TaskRunner/TaskParser.cs
+++ b/src/TaskRunner/TaskParser.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Cake.VisualStudio.Helpers;
@@ -13,13 +12,16 @@ namespace Cake.VisualStudio.TaskRunner
 {
     class TaskParser
     {
+        private static string _loadPattern = "#load \"";
         public static SortedList<string, string> LoadTasks(string configPath)
         {
             var list = new SortedList<string, string>();
 
             try
             {
-                var document = File.ReadAllText(configPath);
+                var script = new ScriptContent(configPath);
+                script.Parse(_loadPattern, s => s.Replace("#load", string.Empty).Trim().Trim('"', ';'));
+                var document = script.ToString();
                 var r = new Regex("Task\\([\\w\"](\\w+)\\\"*\\)");
                 var matches = r.Matches(document);
                 var taskNames = matches.Cast<Match>().Select(m => m.Groups[1].Value);


### PR DESCRIPTION
Uses a new ScriptContent type to support nested Cake files (including nested files inside nested files, which a plain string replacement struggles with)