### PR TITLE
GH47: Add support for Cake-specific language/IDE settings

### DIFF
--- a/src/Cake.VisualStudio.csproj
+++ b/src/Cake.VisualStudio.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Editor\LineExtensions.cs" />
     <Compile Include="Editor\SmartIndentProvider.cs" />
     <Compile Include="Editor\SmartIndent.cs" />
+    <Compile Include="ContentType\CakeLanguageService.cs" />
     <Compile Include="Helpers\Constants.cs" />
     <Compile Include="Helpers\Extensions.cs" />
     <Compile Include="Helpers\PathHelpers.cs" />
@@ -212,6 +213,7 @@
       <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.14.2.25123\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Editor, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Imaging.14.2.25123\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
       <Private>True</Private>
@@ -221,6 +223,7 @@
       <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Package.LanguageService.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.2.25123\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
       <Private>True</Private>
@@ -312,10 +315,6 @@
     <Reference Include="Microsoft.VisualStudio.Validation, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.VisualStudio">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\4v3eeiix.gk5\NuGet.VisualStudio.dll</HintPath>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/CakePackage.cs
+++ b/src/CakePackage.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using System.ComponentModel.Design;
+using Cake.VisualStudio.ContentType;
 using Cake.VisualStudio.Helpers;
 using EnvDTE;
 using EnvDTE80;
@@ -18,6 +20,8 @@ namespace Cake.VisualStudio
     [ProvideAutoLoad(UIContextGuids80.SolutionExists)]
     [Guid(PackageGuids.GuidCakePackageString)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
+    [ProvideLanguageService(typeof(CakeLanguageService), Helpers.Constants.CakeContentType, 100)]
+    [ProvideLanguageExtension(typeof(CakeLanguageService), ".cake")]
     public sealed partial class CakePackage : Package, IVsShellPropertyEvents
     {
         private static DTE2 _dte;

--- a/src/ContentType/CakeLanguageService.cs
+++ b/src/ContentType/CakeLanguageService.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.VisualStudio.Helpers;
+using Microsoft.VisualStudio.Package;
+using Microsoft.VisualStudio.TextManager.Interop;
+using System.Runtime.InteropServices;
+
+namespace Cake.VisualStudio.ContentType
+{
+    [Guid("60914246-A28E-488D-AEB7-34CCDD35FC56")]
+    class CakeLanguageService : LanguageService
+    {
+        private LanguagePreferences preferences = null;
+        public override LanguagePreferences GetLanguagePreferences()
+        {
+            if (preferences == null)
+            {
+                preferences = new LanguagePreferences(Site, typeof(CakeLanguageService).GUID, Name);
+
+                if (preferences != null)
+                {
+                    preferences.Init();
+                    preferences.EnableCodeSense = true;
+                    preferences.EnableMatchBraces = true;
+                    preferences.EnableMatchBracesAtCaret = true;
+                    preferences.EnableShowMatchingBrace = true;
+                    preferences.EnableCommenting = true; ;
+                    preferences.HighlightMatchingBraceFlags = _HighlightMatchingBraceFlags.HMB_USERECTANGLEBRACES;
+                    preferences.LineNumbers = true;
+                    preferences.MaxErrorMessages = 100;
+                    preferences.AutoOutlining = false;
+                    preferences.MaxRegionTime = 2000;
+                    preferences.ShowNavigationBar = false;
+                    preferences.InsertTabs = false;
+                    preferences.IndentSize = 2;
+                    preferences.ShowNavigationBar = false;
+                    preferences.WordWrap = true;
+                    preferences.WordWrapGlyphs = true;
+                    preferences.AutoListMembers = true;
+                    preferences.EnableQuickInfo = true;
+                    preferences.ParameterInformation = true;
+                }
+            }
+
+            return preferences;
+        }
+
+        public CakeLanguageService(object site)
+        {
+            SetSite(site);
+        }
+
+        public override IScanner GetScanner(IVsTextLines buffer)
+        {
+            return null;
+        }
+
+        public override AuthoringScope ParseSource(ParseRequest req)
+        {
+            return null;
+        }
+
+        public override string GetFormatFilterList()
+        {
+            return "Cake script (*.cake)|*.cake;";
+        }
+
+        public override string Name => Constants.CakeContentType;
+    }
+}


### PR DESCRIPTION
Hold off merging this until I have a chance to test after #44 is merged in.

This adds a new "Cake" node under the "Text Editor" options node to configure things like wrapping, indentation and scroll bars (including map mode!) to be specific to `.cake` files.

Resolves #47 