### PR TITLE
(GH-52) Rework regex to allow whitespace

### DIFF
--- a/src/TaskRunner/TaskParser.cs
+++ b/src/TaskRunner/TaskParser.cs
@@ -22,7 +22,7 @@ namespace Cake.VisualStudio.TaskRunner
                 var script = new ScriptContent(configPath);
                 script.Parse(_loadPattern, s => s.Replace("#load", string.Empty).Trim().Trim('"', ';'));
                 var document = script.ToString();
-                var r = new Regex("Task\\([\\w\\\"](.+)\\b\\\"*\\)");
+                var r = new Regex("Task\\s*\\(\\s*\\\"(.+)\\b\\\"\\s*\\)");
                 var matches = r.Matches(document);
                 var taskNames = matches.Cast<Match>().Select(m => m.Groups[1].Value);
                 foreach (var name in taskNames)


### PR DESCRIPTION
Some projects may enforce special coding style guidelines on their
projects. To be more flexible in this area the new regex will now allow
whitespace before and in between the brackets. Following some examples of
allowed task name definitions.

    Task("F_0$0")
    Task( "F_0$0" )
    Task ( "F_0$0" )
    Task ( "F_0$0" )
    Task(
      "F_0$0"
    )
    Task (
      "F_0$0"
    )
    Task (
    	"F_0$0"
    )

@agc93 can you check if this will break you requirements?