### PR TITLE
GH54: Add support for drag-and-drop with cake and dll files

### DIFF
--- a/src/Cake.VisualStudio.csproj
+++ b/src/Cake.VisualStudio.csproj
@@ -93,6 +93,9 @@
     <Compile Include="Editor\SmartIndentProvider.cs" />
     <Compile Include="Editor\SmartIndent.cs" />
     <Compile Include="ContentType\CakeLanguageService.cs" />
+    <Compile Include="Editor\CakeDropHandler.cs" />
+    <Compile Include="Editor\CakeScriptDropHandler.cs" />
+    <Compile Include="Editor\CakeScriptDropHandlerProvider.cs" />
     <Compile Include="Helpers\Constants.cs" />
     <Compile Include="Helpers\Extensions.cs" />
     <Compile Include="Helpers\PathHelpers.cs" />

--- a/src/Editor/CakeDropHandler.cs
+++ b/src/Editor/CakeDropHandler.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text.Editor.DragDrop;
+
+namespace Cake.VisualStudio.Editor
+{
+    internal abstract class CakeDropHandler : IDropHandler
+    {
+        public DragDropPointerEffects HandleDragStarted(DragDropInfo dragDropInfo)
+        {
+            return DragDropPointerEffects.All;
+        }
+
+        public DragDropPointerEffects HandleDraggingOver(DragDropInfo dragDropInfo)
+        {
+            return DragDropPointerEffects.All;
+        }
+
+        public abstract DragDropPointerEffects HandleDataDropped(DragDropInfo dragDropInfo);
+
+        public abstract bool IsDropEnabled(DragDropInfo dragDropInfo);
+
+        public void HandleDragCanceled()
+        {
+            
+        }
+    }
+}

--- a/src/Editor/CakeScriptDropHandler.cs
+++ b/src/Editor/CakeScriptDropHandler.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.DragDrop;
+
+namespace Cake.VisualStudio.Editor
+{
+    internal class CakeScriptDropHandler : CakeDropHandler
+    {
+        private readonly FileInfo _scriptFile;
+        private string _targetFileName;
+        private readonly IWpfTextView _textView;
+        private ITextDocument _document;
+        private readonly string[] _supportedFileExtensions = new[] {".cake", ".dll"};
+
+        public CakeScriptDropHandler(IWpfTextView textView, ITextDocument currentDocument)
+        {
+            _textView = textView;
+            _scriptFile = new FileInfo(currentDocument.FilePath);
+            _document = currentDocument;
+        }
+
+        public override DragDropPointerEffects HandleDataDropped(DragDropInfo dragDropInfo)
+        {
+            try
+            {
+                var relativePath = PackageUtilities.MakeRelative(_scriptFile.FullName, _targetFileName)
+                    .Replace("\\", "/");
+                string insertString = null;
+                switch (Path.GetExtension(relativePath))
+                {
+                    case ".cake":
+                        insertString = $"#load \"{relativePath}\"";
+                        break;
+                    case ".dll":
+                        insertString = $"#r \"{relativePath}\"";
+                        break;
+                }
+                
+                using (var edit = _textView.TextBuffer.CreateEdit())
+                {
+                    edit.Insert(GetInsertPosition(), insertString + Environment.NewLine);
+                    edit.Apply();
+                }
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            return DragDropPointerEffects.Copy;
+        }
+
+        private int GetInsertPosition()
+        {
+            // need to improve logic here to find the first non-#load'ing line in the document.
+            return 0;
+        }
+
+        public override bool IsDropEnabled(DragDropInfo dragDropInfo)
+        {
+            _targetFileName = GetScriptFileName(dragDropInfo);
+            if (_targetFileName == null) return false;
+            var ext = Path.GetExtension(_targetFileName);
+            return _supportedFileExtensions.Contains(ext, StringComparer.OrdinalIgnoreCase) &&
+                   (File.Exists(_targetFileName) || Directory.Exists(_targetFileName));
+        }
+
+        private static string GetScriptFileName(DragDropInfo dragDropInfo)
+        {
+            var data = new DataObject(dragDropInfo.Data);
+
+            if (dragDropInfo.Data.GetDataPresent("FileDrop"))
+            {
+                var files = data.GetFileDropList();
+
+                if (files.Count == 1)
+                {
+                    return files[0];
+                }
+            }
+            else if (dragDropInfo.Data.GetDataPresent("CF_VSSTGPROJECTITEMS") || dragDropInfo.Data.GetDataPresent("CF_VSREFPROJECTITEMS"))
+            {
+                return data.GetText();
+            }
+            else if (dragDropInfo.Data.GetDataPresent("MultiURL"))
+            {
+                return data.GetText();
+            }
+            return null;
+        }
+    }
+}

--- a/src/Editor/CakeScriptDropHandlerProvider.cs
+++ b/src/Editor/CakeScriptDropHandlerProvider.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.VisualStudio.Classifier.Languages;
+using Cake.VisualStudio.Helpers;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.DragDrop;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Cake.VisualStudio.Editor
+{
+    [Export(typeof(IDropHandlerProvider))]
+    [DropFormat("CF_VSSTGPROJECTITEMS")]
+    [DropFormat("CF_VSREFPROJECTITEMS")]
+    [DropFormat("FileDrop")]
+    [Name("CakeDropHandler")]
+    [ContentType(Constants.CakeContentType)]
+    [Order(Before = "DefaultFileDropHandler")]
+    class CakeScriptDropHandlerProvider : IDropHandlerProvider
+    {
+        [Import]
+        ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
+        public IDropHandler GetAssociatedDropHandler(IWpfTextView wpfTextView)
+        {
+            ITextDocument document;
+
+            if (TextDocumentFactoryService.TryGetTextDocument(wpfTextView.TextBuffer, out document))
+            {
+                return
+                    wpfTextView.Properties.GetOrCreateSingletonProperty(
+                        () => new CakeScriptDropHandler(wpfTextView, document));
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This adds support for customised drag-and-drop behaviour.

To start, this is based on #54 , and will `#load` any `.cake` file dropped on the editor, and will `#r` any `.dll` file dropped on the editor. Existing VS behaviour is unchanged.

I've implemented a `CakeDropHandler` that should make it easier to add more handlers for other behaviour as well.

Resolves #54 