### PR TITLE
Update Cake dependencies/templates to 0.19.4

### DIFF
--- a/src/Cake.VisualStudio.csproj
+++ b/src/Cake.VisualStudio.csproj
@@ -142,13 +142,13 @@
       <SubType>Designer</SubType>
     </Content>
     <None Include="packages.config" />
-    <Content Include="..\packages\cake.core.0.17.0\cake.core.0.17.0.nupkg">
+    <Content Include="..\packages\cake.core.0.19.4\cake.core.0.19.4.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\Cake.Testing.0.17.1\cake.testing.0.17.1.nupkg">
+    <Content Include="..\packages\Cake.Testing.0.19.4\cake.testing.0.19.4.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net451" developmentDependency="true" />
-  <package id="Cake.Testing" version="0.17.1" targetFramework="net451" developmentDependency="true" />
   <package id="ini-parser" version="2.3.0" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="14.2.25123" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.Imaging" version="14.2.25123" targetFramework="net451" />
@@ -28,6 +26,8 @@
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net451" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net451" developmentDependency="true" />
   <package id="TemplateBuilder" version="1.1.4.5-beta" targetFramework="net451" />
+  <package id="Cake.Core" version="0.19.4" targetFramework="net451" developmentDependency="true" />
+  <package id="Cake.Testing" version="0.19.4" targetFramework="net451" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net451" developmentDependency="true" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" developmentDependency="true" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" developmentDependency="true" />

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -31,8 +31,8 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="Snippets\snippets.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="ContentType\icons.pkgdef" />
-    <Asset Type="cake.core.0.17.0.nupkg" d:Source="File" Path="Packages\cake.core.0.17.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="cake.testing.0.17.1.nupkg" d:Source="File" Path="Packages\cake.testing.0.17.1.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="cake.core.0.19.4.nupkg" d:Source="File" Path="Packages\cake.core.0.19.4.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="cake.testing.0.19.4.nupkg" d:Source="File" Path="Packages\cake.testing.0.19.4.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="xunit.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.2.1.0.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="xunit.abstractions.2.0.1.nupkg" d:Source="File" Path="Packages\xunit.abstractions.2.0.1.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="xunit.assert.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.assert.2.1.0.nupkg" d:VsixSubPath="Packages" />

--- a/template/AddinTemplate/AddinTemplate.vstemplate
+++ b/template/AddinTemplate/AddinTemplate.vstemplate
@@ -25,7 +25,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="3cf9b016-d63f-44ee-849d-6f3efc996134">
-      <package id="Cake.Core" version="0.17.0" />
+      <package id="Cake.Core" version="0.19.4" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/template/AddinTestBasicTemplate/AddinTestBasicTemplate.vstemplate
+++ b/template/AddinTestBasicTemplate/AddinTestBasicTemplate.vstemplate
@@ -26,8 +26,8 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="3cf9b016-d63f-44ee-849d-6f3efc996134">
-      <package id="Cake.Core" version="0.17.0" />
-      <package id="Cake.Testing" version="0.17.1" />
+      <package id="Cake.Core" version="0.19.4" />
+      <package id="Cake.Testing" version="0.19.4" />
       <package id="xunit" version="2.1.0" targetFramework="net452" />
       <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
       <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/template/AddinTestTemplate/AddinTestTemplate.vstemplate
+++ b/template/AddinTestTemplate/AddinTestTemplate.vstemplate
@@ -29,8 +29,8 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="3cf9b016-d63f-44ee-849d-6f3efc996134">
-      <package id="Cake.Core" version="0.17.0" />
-      <package id="Cake.Testing" version="0.17.1" />
+      <package id="Cake.Core" version="0.19.4" />
+      <package id="Cake.Testing" version="0.19.4" />
       <package id="xunit" version="2.1.0" targetFramework="net452" />
       <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
       <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/template/ModuleTemplate/ModuleTemplate.vstemplate
+++ b/template/ModuleTemplate/ModuleTemplate.vstemplate
@@ -28,7 +28,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="3cf9b016-d63f-44ee-849d-6f3efc996134">
-      <package id="Cake.Core" version="0.17.0" />
+      <package id="Cake.Core" version="0.19.4" />
     </packages>
   </WizardData>
 </VSTemplate>


### PR DESCRIPTION
~~**This will need to be rebased once #67 is merged**~~

This updates the templates to using Cake 0.19.4.

Resolves #50