### PR TITLE
Re-target to .NET Framework 4.6 and update NuGet dependencies

### DIFF
--- a/src/Cake.VisualStudio.csproj
+++ b/src/Cake.VisualStudio.csproj
@@ -27,6 +27,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>
@@ -44,7 +45,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.VisualStudio</RootNamespace>
     <AssemblyName>Cake.VisualStudio</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -141,6 +142,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <SubType>Designer</SubType>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <Content Include="..\packages\cake.core.0.19.4\cake.core.0.19.4.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -154,43 +156,43 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\xunit.2.1.0\xunit.2.1.0.nupkg">
+    <Content Include="..\packages\xunit.2.2.0\xunit.2.2.0.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\xunit.runner.visualstudio.2.1.0\xunit.runner.visualstudio.2.1.0.nupkg">
+    <Content Include="..\packages\xunit.runner.visualstudio.2.2.0\xunit.runner.visualstudio.2.2.0.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\xunit.abstractions.2.0.0\xunit.abstractions.2.0.0.nupkg">
+    <Content Include="..\packages\xunit.abstractions.2.0.1\xunit.abstractions.2.0.1.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\xunit.assert.2.1.0\xunit.assert.2.1.0.nupkg">
+    <Content Include="..\packages\xunit.assert.2.2.0\xunit.assert.2.2.0.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\xunit.core.2.1.0\xunit.core.2.1.0.nupkg">
+    <Content Include="..\packages\xunit.core.2.2.0\xunit.core.2.2.0.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\xunit.extensibility.core.2.1.0\xunit.extensibility.core.2.1.0.nupkg">
+    <Content Include="..\packages\xunit.extensibility.core.2.2.0\xunit.extensibility.core.2.2.0.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <InProject>false</InProject>
     </Content>
-    <Content Include="..\packages\xunit.extensibility.execution.2.1.0\xunit.extensibility.execution.2.1.0.nupkg">
+    <Content Include="..\packages\xunit.extensibility.execution.2.2.0\xunit.extensibility.execution.2.2.0.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -232,13 +234,13 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.14.2.25123\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Editor, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Imaging, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.14.2.25123\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.15.0.26201\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
@@ -248,7 +250,7 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Package.LanguageService.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.2.25123\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.3.25407\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -264,7 +266,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.14.2.25123\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.14.3.25407\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -303,20 +305,20 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Text.Data.14.2.25123\lib\net45\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.Data.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Text.Logic.14.2.25123\lib\net45\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.Logic.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Text.UI.14.2.25123\lib\net45\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.UI.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.UI.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Text.UI.Wpf.14.2.25123\lib\net45\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.UI.Wpf.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -327,16 +329,16 @@
       <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.14.2.25123\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Validation, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.0.82\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/src/app.config
+++ b/src/app.config
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.Logic" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.Data" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.UI" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.UI.Wpf" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Utilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Imaging" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,38 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ini-parser" version="2.3.0" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.CoreUtility" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Imaging" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.14.0" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="11.0.50727" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Immutable.12.0" version="12.0.21003" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Immutable.14.0" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="12.0.30110" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Text.Data" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Text.Logic" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Text.UI" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Threading" version="14.1.131" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Utilities" version="14.2.25123" targetFramework="net451" />
-  <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net451" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net451" developmentDependency="true" />
-  <package id="TemplateBuilder" version="1.1.4.5-beta" targetFramework="net451" />
-  <package id="Cake.Core" version="0.19.4" targetFramework="net451" developmentDependency="true" />
-  <package id="Cake.Testing" version="0.19.4" targetFramework="net451" developmentDependency="true" />
-  <package id="xunit" version="2.1.0" targetFramework="net451" developmentDependency="true" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" developmentDependency="true" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net451" developmentDependency="true" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net451" developmentDependency="true" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net451" developmentDependency="true" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net451" developmentDependency="true" />
+  <package id="Cake.Core" version="0.19.4" targetFramework="net46" developmentDependency="true" />
+  <package id="Cake.Testing" version="0.19.4" targetFramework="net46" developmentDependency="true" />
+  <package id="ini-parser" version="2.3.0" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Imaging" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="11.0.50727" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.12.0" version="12.0.21003" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.14.0" version="14.3.25407" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="12.0.30110" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.Data" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.Logic" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.UI" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net46" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
+  <package id="TemplateBuilder" version="1.1.4.5-beta" targetFramework="net46" />
+  <package id="xunit" version="2.2.0" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -33,13 +33,13 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="ContentType\icons.pkgdef" />
     <Asset Type="cake.core.0.19.4.nupkg" d:Source="File" Path="Packages\cake.core.0.19.4.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="cake.testing.0.19.4.nupkg" d:Source="File" Path="Packages\cake.testing.0.19.4.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xunit.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.2.1.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.2.2.0.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="xunit.abstractions.2.0.1.nupkg" d:Source="File" Path="Packages\xunit.abstractions.2.0.1.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xunit.assert.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.assert.2.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xunit.core.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.core.2.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xunit.extensibility.core.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.core.2.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xunit.extensibility.execution.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.execution.2.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="xunit.runner.visualstudio.2.1.0.nupkg" d:Source="File" Path="Packages\xunit.runner.visualstudio.2.1.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.assert.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.assert.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.core.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.core.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.extensibility.core.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.core.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.extensibility.execution.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.execution.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.runner.visualstudio.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.runner.visualstudio.2.2.0.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="AddinTemplate" d:TargetPath="|AddinTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="ItemTemplate" d:TargetPath="|ItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="ModuleTemplate" d:TargetPath="|ModuleTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />

--- a/template/AddinTestBasicTemplate/AddinTestBasicTemplate.vstemplate
+++ b/template/AddinTestBasicTemplate/AddinTestBasicTemplate.vstemplate
@@ -28,13 +28,13 @@
     <packages repository="extension" repositoryId="3cf9b016-d63f-44ee-849d-6f3efc996134">
       <package id="Cake.Core" version="0.19.4" />
       <package id="Cake.Testing" version="0.19.4" />
-      <package id="xunit" version="2.1.0" targetFramework="net452" />
+      <package id="xunit" version="2.2.0" targetFramework="net452" />
       <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
-      <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net452" />
+      <package id="xunit.assert" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.core" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/template/AddinTestTemplate/AddinTestTemplate.vstemplate
+++ b/template/AddinTestTemplate/AddinTestTemplate.vstemplate
@@ -31,13 +31,13 @@
     <packages repository="extension" repositoryId="3cf9b016-d63f-44ee-849d-6f3efc996134">
       <package id="Cake.Core" version="0.19.4" />
       <package id="Cake.Testing" version="0.19.4" />
-      <package id="xunit" version="2.1.0" targetFramework="net452" />
+      <package id="xunit" version="2.2.0" targetFramework="net452" />
       <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
-      <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
-      <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net452" />
+      <package id="xunit.assert" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.core" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
+      <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" />
     </packages>
   </WizardData>
 </VSTemplate>


### PR DESCRIPTION
Changes target framework to .NET 4.6, updates VSSDK packages to latest supported, and updates xUnit dependencies to 2.2.0.

Resolves #72 .