### PR TITLE
GH-84 Fix. "protectedIdentifiers" can be null

### DIFF
--- a/src/Helpers/Extensions.cs
+++ b/src/Helpers/Extensions.cs
@@ -47,7 +47,7 @@ namespace Cake.VisualStudio.Helpers
         internal static bool RequiresOffset(this ITextSnapshotLine line, params string[] protectedIdentifiers)
         {
             var content = line.GetText().TrimEnd();
-            return protectedIdentifiers.Any(i => content.EndsWith(i));
+            return protectedIdentifiers?.Any(i => content.EndsWith(i)) ?? false;
         } 
     }
 }


### PR DESCRIPTION
VS extension crashes because protectedIdentifiers throws unexpected NullReferenceException.