### PR TITLE
Update to new VS2019 SDKs and APIs. Migrate to an AsyncPackage load.

### DIFF
--- a/src/CakePackage.cs
+++ b/src/CakePackage.cs
@@ -3,38 +3,42 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.ComponentModel.Design;
 using Cake.VisualStudio.ContentType;
 using Cake.VisualStudio.Helpers;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Threading;
+using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Cake.VisualStudio
 {
-    [PackageRegistration(UseManagedResourcesOnly = true)]
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [InstalledProductRegistration("#110", "#112", Vsix.Version, IconResourceID = 400)]
-    [ProvideAutoLoad(UIContextGuids80.SolutionExists)]
+    [ProvideAutoLoad(UIContextGuids80.SolutionExists, PackageAutoLoadFlags.BackgroundLoad)]
     [Guid(PackageGuids.guidCakePackageString)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideLanguageService(typeof(CakeLanguageService), Helpers.Constants.CakeContentType, 100)]
     [ProvideLanguageExtension(typeof(CakeLanguageService), ".cake")]
-    public sealed partial class CakePackage : Package, IVsShellPropertyEvents
+    public sealed partial class CakePackage : AsyncPackage, IVsShellPropertyEvents
     {
         private static DTE2 _dte;
         internal static DTE2 Dte => _dte ?? (_dte = (DTE2) GetGlobalService(typeof(DTE)));
         internal static IVsUIShell Shell => _shell ?? (_shell = (IVsUIShell) GetGlobalService(typeof(IVsUIShell)));
-
         uint _cookie;
         private static IVsUIShell _shell;
 
-        protected override void Initialize()
+        protected override async System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             Logger.Initialize(this, Vsix.Name);
-            base.Initialize();
+            //base.Initialize();
+
+            // switch to the UI thread
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             var shellService = GetService(typeof(SVsShell)) as IVsShell;
 
             if (shellService != null)
@@ -45,6 +49,7 @@ namespace Cake.VisualStudio
             Menus.InstallBootstrapperCommand.Initialize(this);
             Menus.InstallShellBootstrapperCommand.Initialize(this);
             Menus.InstallConfigFileCommand.Initialize(this);
+            //return base.InitializeAsync(cancellationToken, progress);
         }
 
         public static bool IsDocumentDirty(string documentPath, out IVsPersistDocData persistDocData)
@@ -74,15 +79,15 @@ namespace Cake.VisualStudio
                 if ((bool)var == false)
                 {
                     // zombie state dependent code
-
                     // Dte = (DTE2)GetService(typeof(DTE));
                     // eventlistener no longer needed
 
                     var shellService = GetService(typeof(SVsShell)) as IVsShell;
 
                     if (shellService != null)
-
+                    {
                         ErrorHandler.ThrowOnFailure(shellService.UnadviseShellPropertyChanges(_cookie));
+                    }
 
                     _cookie = 0;
                 }

--- a/src/Menus/InstallBootstrapperCommand.cs
+++ b/src/Menus/InstallBootstrapperCommand.cs
@@ -38,12 +38,7 @@ namespace Cake.VisualStudio.Menus
         /// <param name="package">Owner _package, not null.</param>
         private InstallBootstrapperCommand(Package package)
         {
-            if (package == null)
-            {
-                throw new ArgumentNullException("package");
-            }
-
-            _package = package;
+            _package = package ?? throw new ArgumentNullException("package");
 
             var commandService = ServiceProvider.GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (commandService != null)

--- a/src/Menus/InstallConfigFileCommand.cs
+++ b/src/Menus/InstallConfigFileCommand.cs
@@ -38,12 +38,7 @@ namespace Cake.VisualStudio.Menus
         /// <param name="package">Owner _package, not null.</param>
         private InstallConfigFileCommand(Package package)
         {
-            if (package == null)
-            {
-                throw new ArgumentNullException("package");
-            }
-
-            _package = package;
+            _package = package ?? throw new ArgumentNullException("package");
 
             var commandService = ServiceProvider.GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (commandService != null)

--- a/src/Menus/InstallShellBootstrapperCommand.cs
+++ b/src/Menus/InstallShellBootstrapperCommand.cs
@@ -38,12 +38,7 @@ namespace Cake.VisualStudio.Menus
         /// <param name="package">Owner _package, not null.</param>
         private InstallShellBootstrapperCommand(Package package)
         {
-            if (package == null)
-            {
-                throw new ArgumentNullException("package");
-            }
-
-            _package = package;
+            _package = package ?? throw new ArgumentNullException("package");
 
             var commandService = ServiceProvider.GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (commandService != null)

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,51 +1,50 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="3cf9b016-d63f-44ee-849d-6f3efc996134" Version="0.1.1.0" Language="en-US" Publisher="Cake Build" />
-        <DisplayName>Cake for Visual Studio</DisplayName>
-        <Description xml:space="preserve">Adds support for the Cake build tool in Visual Studio 2015 and 2017. Includes support for the Task Runner Explorer, new templates and bootstrapping important Cake files.</Description>
-        <MoreInfo>https://github.com/cake-build/cake-vs</MoreInfo>
-        <License>Resources\LICENSE</License>
-        <Icon>Resources\icon.png</Icon>
-        <PreviewImage>Resources\preview.png</PreviewImage>
-        <Tags>cake, build</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Professional" Version="[14.0,15.0]" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[14.0,15.0]" />
-    </Installation>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.Net.Component.4.5.TargetingPack" Version="[15.0,16.0)" DisplayName=".NET Framework 4.5 targeting pack" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,16.0)" DisplayName="C# and Visual Basic" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.Compiler" Version="[15.0,16.0)" DisplayName="C# and Visual Basic Roslyn compilers" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.NuGet" Version="[15.0,16.0)" DisplayName="NuGet package manager" />
-    </Prerequisites>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="Snippets\snippets.pkgdef" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="ContentType\icons.pkgdef" />
-        <Asset Type="cake.core.0.21.1.nupkg" d:Source="File" Path="Packages\cake.core.0.21.1.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="cake.testing.0.21.1.nupkg" d:Source="File" Path="Packages\cake.testing.0.21.1.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="xunit.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.2.2.0.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="xunit.abstractions.2.0.1.nupkg" d:Source="File" Path="Packages\xunit.abstractions.2.0.1.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="xunit.assert.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.assert.2.2.0.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="xunit.core.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.core.2.2.0.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="xunit.extensibility.core.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.core.2.2.0.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="xunit.extensibility.execution.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.execution.2.2.0.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="xunit.runner.visualstudio.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.runner.visualstudio.2.2.0.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="AddinTemplate" d:TargetPath="|AddinTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="ItemTemplate" d:TargetPath="|ItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="ModuleTemplate" d:TargetPath="|ModuleTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="AddinTestTemplate" d:TargetPath="|AddinTestTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="AddinTestBasicTemplate" d:TargetPath="|AddinTestBasicTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="SolutionItemTemplate" d:TargetPath="|SolutionItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-        <!-- <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" /> -->
-    </Assets>
+  <Metadata>
+    <Identity Id="3cf9b016-d63f-44ee-849d-6f3efc996134" Version="0.1.1.0" Language="en-US" Publisher="Cake Build" />
+    <DisplayName>Cake for Visual Studio</DisplayName>
+    <Description xml:space="preserve">Adds support for the Cake build tool in Visual Studio 2015 and 2017. Includes support for the Task Runner Explorer, new templates and bootstrapping important Cake files.</Description>
+    <MoreInfo>https://github.com/cake-build/cake-vs</MoreInfo>
+    <License>Resources\LICENSE</License>
+    <Icon>Resources\icon.png</Icon>
+    <PreviewImage>Resources\preview.png</PreviewImage>
+    <Tags>cake, build</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Professional" Version="[14.0,17.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[14.0,17.0)" />
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.Net.Component.4.5.TargetingPack" Version="[15.0,)" DisplayName=".NET Framework 4.5 targeting pack" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,)" DisplayName="C# and Visual Basic" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.Compiler" Version="[15.0,)" DisplayName="C# and Visual Basic Roslyn compilers" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.NuGet" Version="[15.0,)" DisplayName="NuGet package manager" />
+  </Prerequisites>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="Snippets\snippets.pkgdef" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="ContentType\icons.pkgdef" />
+    <Asset Type="cake.core.0.21.1.nupkg" d:Source="File" Path="Packages\cake.core.0.21.1.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="cake.testing.0.21.1.nupkg" d:Source="File" Path="Packages\cake.testing.0.21.1.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.abstractions.2.0.1.nupkg" d:Source="File" Path="Packages\xunit.abstractions.2.0.1.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.assert.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.assert.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.core.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.core.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.extensibility.core.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.core.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.extensibility.execution.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.extensibility.execution.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="xunit.runner.visualstudio.2.2.0.nupkg" d:Source="File" Path="Packages\xunit.runner.visualstudio.2.2.0.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="AddinTemplate" d:TargetPath="|AddinTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="ItemTemplate" d:TargetPath="|ItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="ModuleTemplate" d:TargetPath="|ModuleTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="AddinTestTemplate" d:TargetPath="|AddinTestTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="AddinTestBasicTemplate" d:TargetPath="|AddinTestBasicTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="SolutionItemTemplate" d:TargetPath="|SolutionItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+    <!-- <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" /> -->
+  </Assets>
 </PackageManifest>

--- a/template/AddinTemplate/AddinTemplate.vstemplate
+++ b/template/AddinTemplate/AddinTemplate.vstemplate
@@ -5,6 +5,11 @@
     <Description>Basic project template for creating a new Cake addin</Description>
     <Icon>AddinTemplate.ico</Icon>
     <ProjectType>CSharp</ProjectType>
+    <LanguageTag>csharp</LanguageTag>
+    <PlatformTag>linux</PlatformTag>
+    <PlatformTag>windows</PlatformTag>
+    <PlatformTag>macos</PlatformTag>
+    <ProjectTypeTag>Cake</ProjectTypeTag>
     <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>10dcbe21-0d84-4a5b-88a3-220e234a7211</TemplateID>

--- a/template/AddinTestBasicTemplate/AddinTestBasicTemplate.vstemplate
+++ b/template/AddinTestBasicTemplate/AddinTestBasicTemplate.vstemplate
@@ -7,6 +7,11 @@
     <Description>Basic project template for creating unit tests for a Cake addin</Description>
     <Icon>CakeTestTemplate.ico</Icon>
     <ProjectType>CSharp</ProjectType>
+    <LanguageTag>csharp</LanguageTag>
+    <PlatformTag>linux</PlatformTag>
+    <PlatformTag>windows</PlatformTag>
+    <PlatformTag>macos</PlatformTag>
+    <ProjectTypeTag>Cake</ProjectTypeTag>
     <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>8632940c-cc4f-4a8a-abc9-79c00818f4ef</TemplateID>

--- a/template/AddinTestTemplate/AddinTestTemplate.vstemplate
+++ b/template/AddinTestTemplate/AddinTestTemplate.vstemplate
@@ -7,6 +7,11 @@
     <Description>Basic project template, including samples, for creating unit tests for a Cake addin</Description>
     <Icon>CakeTestTemplate.ico</Icon>
     <ProjectType>CSharp</ProjectType>
+    <LanguageTag>csharp</LanguageTag>
+    <PlatformTag>linux</PlatformTag>
+    <PlatformTag>windows</PlatformTag>
+    <PlatformTag>macos</PlatformTag>
+    <ProjectTypeTag>Cake</ProjectTypeTag>
     <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>8e115642-736f-4d2d-975e-551dbfc1a088</TemplateID>

--- a/template/ItemTemplate/ItemTemplate.vstemplate
+++ b/template/ItemTemplate/ItemTemplate.vstemplate
@@ -6,6 +6,8 @@
     <Icon>ItemTemplate.ico</Icon>
     <TemplateID>7d181506-47e9-4f9d-8ac3-5ac65f6b8354</TemplateID>
     <ProjectType>CSharp</ProjectType>
+    <LanguageTag>csharp</LanguageTag>
+    <ProjectTypeTag>Cake</ProjectTypeTag>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>build.cake</DefaultName>
   </TemplateData>

--- a/template/ModuleTemplate/ModuleTemplate.vstemplate
+++ b/template/ModuleTemplate/ModuleTemplate.vstemplate
@@ -7,6 +7,11 @@
     <Description>Basic project template for creating a new Cake module, including a sample module.</Description>
     <Icon>ModuleTemplate.ico</Icon>
     <ProjectType>CSharp</ProjectType>
+    <LanguageTag>csharp</LanguageTag>
+    <PlatformTag>linux</PlatformTag>
+    <PlatformTag>windows</PlatformTag>
+    <PlatformTag>macos</PlatformTag>
+    <ProjectTypeTag>Cake</ProjectTypeTag>
     <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>5e03cc59-29b1-40df-a2a4-042532a23176</TemplateID>


### PR DESCRIPTION
This transitions to `AsyncPackage` (going to be required in future), updates references to support VSSDK 16.x and updated template format. Resolves #101.

I have tested against VS2019 Preview 4.3 and it looks like this is all that's needed for VS2019 support. Resolves #98.